### PR TITLE
YDA-7089: fix statistics issue data last month

### DIFF
--- a/stats.py
+++ b/stats.py
@@ -412,9 +412,19 @@ def get_resource_monthly_category_stats(ctx: rule.Context) -> Dict:
             elif len(group_storage[group]) == record_count:
                 group_storage[group].append(0)
 
-        # Increment time period by 1 month
-        min_date = min_date + relativedelta(months=+1)
         record_count += 1
+
+        # Increment time period by 1 month, but take care not to skip
+        # the iteration for the current month.
+        date_one_month_later = min_date + relativedelta(months=+1)
+        if min_date < current_date and date_one_month_later < current_date:
+            min_date = date_one_month_later
+        elif min_date < current_date:
+            # Do one last iteration with current year and month
+            min_date = current_date
+        elif min_date == current_date:
+            # Current year and month have been processed
+            break
 
     all_storage = [
         {


### PR DESCRIPTION
Export statistics previously sometimes had missing data for the latest month. This was because ruleset function get_resource_monthly_category_stats tries to step through monthly data by adding a month to the date iterator every iteration. This could result in the last month not being included in the monthly data if the current day of the month was before the day of the month of the first statistics data in the environment.